### PR TITLE
Add fixed stats for Drag Race US season 13 queens

### DIFF
--- a/app/(root)/buildcast/page.tsx
+++ b/app/(root)/buildcast/page.tsx
@@ -12,6 +12,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCrown, faPlay, faCheck, faX } from '@fortawesome/free-solid-svg-icons';
 import { Info } from "lucide-react";
 import { Separator } from "@/components/ui/separator"
+import { withQueenStats } from "@/lib/queenStats";
 
 import {
   DndContext,
@@ -59,15 +60,6 @@ const Page = () => {
   const [seasonMode, setSeasonMode] = useState('');
   const [isLoading, setIsLoading] = useState(true); // fix loading issues with the big red Xs
   const router = useRouter();
-
-  const generateRandomStats = () => ({
-    Acting: Math.floor(Math.random() * 101),
-    Dance: Math.floor(Math.random() * 101),
-    Comedy: Math.floor(Math.random() * 101),
-    Design: Math.floor(Math.random() * 101),
-    Runway: Math.floor(Math.random() * 101),
-    Singing: Math.floor(Math.random() * 101),
-  });
 
   const handleSaveToLocalStorage = () => {
     localStorage.setItem("selectedQueens", JSON.stringify(queenCards));
@@ -123,7 +115,7 @@ const Page = () => {
     let parsedEps: any[] = [];
 
     if (savedQueens) {
-      parsedQueens = JSON.parse(savedQueens);
+      parsedQueens = JSON.parse(savedQueens).map((queen: any) => withQueenStats(queen));
       parsedQueens.sort((a: any, b: any) => a.name.localeCompare(b.name));
       setQueenCards(parsedQueens);
     }
@@ -453,7 +445,7 @@ const Page = () => {
                       Queens
                     </h2>
                     <p className="mt-2 text-sm font-medium text-purple-800">Select the queens that you wish you wish to compete in this season!
-                      <br /> You can also edit their stats by entering a number between 1-100 - the higher the stat the better! (or keep them randomly generated)</p>
+                      <br /> You can also edit their stats by entering a number between 1-100 - the higher the stat the better!</p>
                   </div>
                 </div>
 
@@ -466,10 +458,7 @@ const Page = () => {
                       if (prev.some((q) => q.id === queen.id)) return prev;
                       return [
                         ...prev,
-                        {
-                          ...queen,
-                          stats: generateRandomStats(),
-                        },
+                        withQueenStats(queen),
                       ];
                     });
                   }}

--- a/components/QueenCard.tsx
+++ b/components/QueenCard.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import Image from "next/image";
 import * as Flags from 'country-flag-icons/react/3x2';
 import { X, ChevronLeft, ChevronRight } from "lucide-react";
+import { QueenStats } from "@/lib/queenStats";
 
 import {
   Accordion,
@@ -11,15 +12,6 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion"
-
-type QueenStats = {
-
-  Acting: number;
-  Dance: number;
-  Comedy: number;
-  Design: number;
-  Singing: number;
-};
 
 type Queen = {
   id: string;

--- a/components/SimLayout.tsx
+++ b/components/SimLayout.tsx
@@ -5,6 +5,7 @@ import CardList from "./CardList";
 import { mainChallenge } from "@/lib/utils";
 import EpisodeList from "./EpisodeList";
 import EpisodeMessage from "./EpisodeMessage";
+import { generateQueenStats } from "@/lib/queenStats";
 
 type Placement = {
   episodeNumber: number | string;
@@ -39,14 +40,7 @@ const SimLayout = (
       highs: 0,
       lows: 0,
       isEliminated: false,
-      stats: q.stats ?? {
-        Acting: Math.floor(Math.random() * 100) + 1,
-        Dance: Math.floor(Math.random() * 100) + 1,
-        Comedy: Math.floor(Math.random() * 100) + 1,
-        Design: Math.floor(Math.random() * 100) + 1,
-        Runway: Math.floor(Math.random() * 100) + 1,
-        Singing: Math.floor(Math.random() * 100) + 1,
-      }
+      stats: generateQueenStats(q)
     }));
   }, [queens]);
 

--- a/constants/queenData.ts
+++ b/constants/queenData.ts
@@ -1389,91 +1389,195 @@ export const queens = [
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/3/36/DenaliS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902181626',
     seasons: '13,AS10',
     name: "Denali",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      'Acting': 70,
+      'Dance': 95,
+      'Comedy': 68,
+      'Design': 60,
+      'Runway': 88,
+      'Singing': 72
+    }
   },
   {
     id: 'VDzrunSAdFpQsPiB22dI',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/0/0b/ElliottWith2T%27sS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902181745',
     seasons: '13',
     name: "Elliott With 2 Ts",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      'Acting': 60,
+      'Dance': 88,
+      'Comedy': 55,
+      'Design': 50,
+      'Runway': 70,
+      'Singing': 58
+    }
   },
   {
     id: '4fCfJozI92fuhdLs2UDb',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/a/a7/JoeyJayS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182023',
     seasons: '13',
     name: "Joey Jay",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      'Acting': 65,
+      'Dance': 75,
+      'Comedy': 60,
+      'Design': 45,
+      'Runway': 72,
+      'Singing': 55
+    }
   },
   {
     id: 'auLfJozI92gMgdLs2UDb',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/b/bd/GottmikS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902181947',
     seasons: '13,AS9',
     name: "Gottmik",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      'Acting': 70,
+      'Dance': 60,
+      'Comedy': 75,
+      'Design': 88,
+      'Runway': 92,
+      'Singing': 40
+    }
   },
   {
     id: '7iFdqehdbL0JjOcwdWBy',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/e/e5/KahmoraHallS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182128',
     seasons: '13',
     name: "Kahmora Hall",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      'Acting': 50,
+      'Dance': 45,
+      'Comedy': 40,
+      'Design': 65,
+      'Runway': 90,
+      'Singing': 42
+    }
   },
   {
     id: 'rhOn7RHexb27Hx02pd4u',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/6/63/KandyMuseS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182209',
     seasons: '13,AS8',
     name: "Kandy Muse",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      'Acting': 80,
+      'Dance': 70,
+      'Comedy': 85,
+      'Design': 55,
+      'Runway': 75,
+      'Singing': 65
+    }
   },
   {
     id: 'G5HVACaVRzQcVzDRbzlY',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/e/e0/LaLaRiS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182255',
     seasons: '13,AS8',
     name: "Lala Ri",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      'Acting': 65,
+      'Dance': 78,
+      'Comedy': 70,
+      'Design': 40,
+      'Runway': 68,
+      'Singing': 55
+    }
   },
   {
     id: 'G4fVACaVRzQcVzDRbzlY',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/4/4f/OliviaLuxS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182353',
     seasons: '13,AS10',
     name: "Olivia Luxx",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      'Acting': 72,
+      'Dance': 74,
+      'Comedy': 66,
+      'Design': 58,
+      'Runway': 82,
+      'Singing': 88
+    }
   },
   {
     id: '5jQ3YcBfH0fYLJZupGQL',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/7/74/Ros%C3%A9S13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182428',
     seasons: '13',
     name: "Rosé",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      'Acting': 90,
+      'Dance': 85,
+      'Comedy': 80,
+      'Design': 70,
+      'Runway': 88,
+      'Singing': 92
+    }
   },
   {
     id: '5j4f5cBfH0fYLJZupGQL',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/7/7d/SymoneS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20211216235826',
     seasons: '13',
     name: "Symone",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      'Acting': 85,
+      'Dance': 70,
+      'Comedy': 78,
+      'Design': 65,
+      'Runway': 95,
+      'Singing': 60
+    }
   },
   {
     id: 'tKLXASuGPeb05fVfW55Y',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/3/35/TamishaImanS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182545',
     seasons: '13',
     name: "Tamisha Iman",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      'Acting': 68,
+      'Dance': 70,
+      'Comedy': 62,
+      'Design': 72,
+      'Runway': 80,
+      'Singing': 60
+    }
   },
   {
     id: 'E0PWgyI0x3sQ4ucHxhe4',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/4/44/TinaBurnerS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182624',
     seasons: '13,AS10',
     name: "Tina Burner",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      'Acting': 75,
+      'Dance': 65,
+      'Comedy': 82,
+      'Design': 62,
+      'Runway': 70,
+      'Singing': 78
+    }
   },
   {
     id: 'jpacB8Bl9pJuxad0nSxA',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/d/dc/UticaQueenS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182704',
     seasons: '13',
     name: "Utica Queen",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      'Acting': 74,
+      'Dance': 68,
+      'Comedy': 75,
+      'Design': 85,
+      'Runway': 86,
+      'Singing': 50
+    }
   },
   {
     id: 'ZsPFngAr2xqFXDayn1Vb',

--- a/lib/queenStats.ts
+++ b/lib/queenStats.ts
@@ -1,0 +1,61 @@
+export const STAT_KEYS = ["Acting", "Dance", "Comedy", "Design", "Runway", "Singing"] as const;
+
+export type StatKey = typeof STAT_KEYS[number];
+
+export type QueenStats = Record<StatKey, number>;
+
+type QueenLike = {
+  id?: string;
+  name?: string;
+  stats?: Partial<Record<StatKey, number>> | null;
+};
+
+const clamp = (value: number, min: number, max: number) => {
+  return Math.min(Math.max(Math.round(value), min), max);
+};
+
+const createSeedFromString = (value: string) => {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash << 5) - hash + value.charCodeAt(i);
+    hash |= 0; // Convert to 32bit integer
+  }
+  return hash >>> 0; // Ensure non-negative number
+};
+
+const createGenerator = (initialSeed: number) => {
+  let state = initialSeed >>> 0;
+  if (state === 0) {
+    state = 0x6d2b79f5;
+  }
+
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0; // Linear congruential generator
+    return state / 0xffffffff;
+  };
+};
+
+export const generateQueenStats = (queen: QueenLike): QueenStats => {
+  const baseStats = queen.stats ?? {};
+  const generator = createGenerator(createSeedFromString(`${queen.id ?? ""}|${queen.name ?? ""}`));
+
+  const stats: Partial<QueenStats> = {};
+
+  for (const key of STAT_KEYS) {
+    const existingValue = baseStats[key];
+
+    if (typeof existingValue === "number" && !Number.isNaN(existingValue)) {
+      stats[key] = clamp(existingValue, 1, 100);
+    } else {
+      const generatedValue = Math.floor(generator() * 100) + 1;
+      stats[key] = clamp(generatedValue, 1, 100);
+    }
+  }
+
+  return stats as QueenStats;
+};
+
+export const withQueenStats = <T extends QueenLike>(queen: T): T & { stats: QueenStats } => ({
+  ...queen,
+  stats: generateQueenStats(queen),
+});


### PR DESCRIPTION
## Summary
- add explicit stats for each RuPaul's Drag Race US season 13 queen to the shared queen data list so the deterministic generator uses the supplied values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2a7fe3b448332ad0d2952c0eccd90